### PR TITLE
With Mineunit Badger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # mineunit-actions
-GitHub actions for mt-mods/mineunit
 
-Executes Lua unit tests with `busted` in `spec` directory with code coverage analysis using `cluacov` and generates badge for coverage.
+Executes Minetest Lua mod unit tests with [`mineunit`](https://github.com/mt-mods/mineunit) in `spec` directory with code coverage analysis generating badges for coverage.
 
 Example badges:
-* ![](https://byob.yarr.is/S-S-X/metatool/metatool-coverage)
-* ![](https://byob.yarr.is/S-S-X/metatool/sharetool-coverage)
+* ![mineunit](https://mineunit-badges.000webhostapp.com/S-S-X/fence_connect/coverage)
+* ![mineunit](https://mineunit-badges.000webhostapp.com/S-S-X/metatool/metatool-coverage)
 
 Examples in projects:
 * https://github.com/S-S-X/metatool
 * https://github.com/S-S-X/qos
 * https://github.com/mt-mods/technic
 * https://github.com/mt-mods/machine_parts
+
+## Example setup
 
 Example workflow file `.github/workflows/mineunit.yml`:
 ```yaml
@@ -24,32 +25,38 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - id: mineunit
-      uses: mt-mods/mineunit-actions@master
+      uses: mt-mods/mineunit-actions@v0.3
       with:
-        badge-color: "CC9909"
-    - uses: RubbaBoy/BYOB@v1.2.0
-      with:
-        NAME: "${{ steps.mineunit.outputs.badge-name }}"
-        LABEL: "${{ steps.mineunit.outputs.badge-label }}"
-        STATUS: "${{ steps.mineunit.outputs.badge-status }}"
-        COLOR: "${{ steps.mineunit.outputs.badge-color }}"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        badge-secret: ${{ secrets.MineunitBadgesAPIKey }}
 ```
 
-Optional parameters for `mt-mods/mineunit-actions`:
+You need to create secret `MineunitBadgesAPIKey` with valid API key to generate and update badges.
+Optionally you can disable badges by removing `badge-secret` or leaving it empty.
 
-* **`working-directory`** Working directory for unit tests
-* **`badge-name`** Code coverage badge name
-* **`badge-label`** Code coverage badge label
-* **`badge-color`** Code coverage badge color
-* **`mineunit-version`** Mineunit version
+## Mineunit-actions parameters and outputs
 
-Outputs:
+#### Optional parameters for `mt-mods/mineunit-actions`:
 
-* **`steps.mineunit.outputs.badge-name`** Code coverage badge name waiting for issues/#1
-* **`steps.mineunit.outputs.badge-label`** Code coverage badge label waiting for issues/#1
-* **`steps.mineunit.outputs.badge-status`** Code coverage badge status waiting for issues/#1
-* **`steps.mineunit.outputs.badge-color`** Code coverage badge color waiting for issues/#1
+* **`working-directory`** Working directory for unit tests.
+	*default:* `.`
+* **`badge-name`** Code coverage badge name (unique id).
+    *default:* `coverage`
+* **`badge-label`** Code coverage badge label.
+	*default:* `Test coverage`
+* **`badge-color`** Code coverage badge color.
+    *default:* `99CC09`
+* **`badge-service`** Custom badge service base URL, see https://github.com/S-S-X/mineunit-badges.
+* **`badge-secret`** Badge service API key, no badges generated if empty.
+* **`production-branch`** Production branch is what is used for badge generation.
+	*default:* `master`
+* **`badge-purge-with`** Purge GitHub Camo links in https://github.com/ path, %s substituted for production-branch.
+	*default:* `"[account|organization]/[repository]/blob/%s/README.md"`
+* **`mineunit-version`** Mineunit version.
+
+#### Outputs that can be used on workflow after Mineunit action completed:
+
+* **`steps.mineunit.outputs.badge-status`** Generated badge status, right hand side text of badge.
+* **`steps.mineunit.outputs.badge-url`** Generated badge URL.
 * **`steps.mineunit.outputs.mineunit-stdout`** Stdout produced during busted run
 * **`steps.mineunit.outputs.mineunit-spec-missing`** Set to true if no spec files found for busted
 * **`steps.mineunit.outputs.mineunit-report`** Mineunit detailed test report

--- a/action.yml
+++ b/action.yml
@@ -127,8 +127,8 @@ runs:
     - name: generate badge
       shell: bash
       run: |
-        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ production-branch }}' ]]"
-        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ production-branch }}' ]] || exit 0
+        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]]"
+        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]] || exit 0
         echo "Check passed, generating badge"
         data='{"label":"${{ inputs.badge-label }}","color":"${{ inputs.badge-color }}","value":"${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"}'
         curl -v -H "Content-Type: application/json" -d "$data" '${{ inputs.badge-service }}/${{ inputs.badge-name }}'

--- a/action.yml
+++ b/action.yml
@@ -144,8 +144,8 @@ runs:
         CAMO=(grep -o '<img[^>]\+src="https://camo.githubusercontent.com/[^>]*data-canonical-src="'"$BADGEURL"'"[^>]\+>')
         LINKS=(sed -rn 's/^.*\ssrc="([^"<>]+)".*$/\1/p')
         echo
-        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' && '${{ inputs.badge-secret }}' =~ ^[^\ ]$ ]]"
-        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' && '${{ inputs.badge-secret }}' =~ ^[^\ ]$ ]] || exit 0
+        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' && '${{ inputs.badge-secret }}' =~ ^[^\ ]+$ ]]"
+        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' && '${{ inputs.badge-secret }}' =~ ^[^\ ]+$ ]] || exit 0
         echo
         data='{"label":"${{ inputs.badge-label }}","color":"${{ inputs.badge-color }}","value":"${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"}'
         "${CURL[@]}" -H "Content-Type: application/json" -d "$data" "${BADGEURL}/${{ inputs.badge-secret }}"

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,9 @@ inputs:
     default: master
 
   badge-purge-with:
-    description: "Purge GitHub Camo caches for links in this https://github.com/ path"
+    description: "Purge GitHub Camo links in https://github.com/ path, %s substituted for production-branch"
     required: true
-    default: "${{ github.repository }}/blob/${{ inputs.production-branch }}/README.md"
+    default: "${{ github.repository }}/blob/%s/README.md"
 
   mineunit-version:
     description: "Mineunit version"
@@ -139,7 +139,7 @@ runs:
       shell: bash
       run: |
         BADGEURL='${{ inputs.badge-service }}/${{ inputs.badge-name }}'
-        CAMO_CHECK_URL='https://github.com/${{ inputs.badge-purge-with }}'
+        CAMO_CHECK_URL="$(printf 'https://github.com/${{ inputs.badge-purge-with }}' '${{ inputs.production-branch }}')"
         CURL=(curl -fsSm 30 -D /dev/stderr --max-redirs 8 --retry-delay 9 --retry 3 --retry-connrefused)
         CAMO=(grep -o '<img[^>]\+src="https://camo.githubusercontent.com/[^>]*data-canonical-src="'"$BADGEURL"'"[^>]\+>')
         LINKS=(sed -rn 's/^.*\ssrc="([^"<>]+)".*$/\1/p')
@@ -152,7 +152,7 @@ runs:
         echo "Badge URL: ${BADGEURL}"
         [[ '${{ inputs.badge-purge-with }}' == '' ]] && exit 0
         echo
-        echo 'Purging Camo caches based on ${{ inputs.badge-purge-with }} links'
+        echo "Purging Camo caches based on $CAMO_CHECK_URL links"
         echo
         "${CURL[@]}" "$CAMO_CHECK_URL" | "${CAMO[@]}" | "${LINKS[@]}" | sort -u > camo.purge.uri
         echo

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     default: "https://mineunit-badges.000webhostapp.com/${{ github.repository }}"
   badge-secret:
     description: "Badge service API key"
-    required: true
+    required: false
 
   production-branch:
     description: "Production branch is what is used for badge generation"
@@ -144,18 +144,16 @@ runs:
         CAMO=(grep -o '<img[^>]\+src="https://camo.githubusercontent.com/[^>]*data-canonical-src="'"$BADGEURL"'"[^>]\+>')
         LINKS=(sed -rn 's/^.*\ssrc="([^"<>]+)".*$/\1/p')
         echo
-        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]]"
-        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]] || exit 0
+        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' && '${{ inputs.badge-secret }}' =~ ^[^\ ]$ ]]"
+        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' && '${{ inputs.badge-secret }}' =~ ^[^\ ]$ ]] || exit 0
         echo
         data='{"label":"${{ inputs.badge-label }}","color":"${{ inputs.badge-color }}","value":"${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"}'
         "${CURL[@]}" -H "Content-Type: application/json" -d "$data" "${BADGEURL}/${{ inputs.badge-secret }}"
         echo "Badge URL: ${BADGEURL}"
         [[ '${{ inputs.badge-purge-with }}' == '' ]] && exit 0
-        echo
         echo "Purging Camo caches based on $CAMO_CHECK_URL links"
         echo
         "${CURL[@]}" "$CAMO_CHECK_URL" | "${CAMO[@]}" | "${LINKS[@]}" | sort -u > camo.purge.uri
-        echo
         echo "Purging cache for $(wc -l < camo.purge.uri) Camo entries"
         echo
         xargs -ra camo.purge.uri "${CURL[@]}" -X PURGE

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ inputs:
     description: "Code coverage badge color"
     required: true
     default: "99CC09"
+
   badge-service:
     description: "Badge service base URL"
     required: true
@@ -29,10 +30,17 @@ inputs:
   badge-secret:
     description: "Badge service API key"
     required: true
+
   production-branch:
     description: "Production branch is what is used for badge generation"
     required: true
     default: master
+
+  badge-purge-with:
+    description: "Purge GitHub Camo caches for links in this https://github.com/ path"
+    required: true
+    default: "${{ github.repository }}/blob/${{ inputs.production-branch }}/README.md"
+
   mineunit-version:
     description: "Mineunit version"
     required: false
@@ -130,8 +138,24 @@ runs:
     - name: generate badge
       shell: bash
       run: |
+        BADGEURL='${{ inputs.badge-service }}/${{ inputs.badge-name }}'
+        CAMO_CHECK_URL='https://github.com/${{ inputs.badge-purge-with }}'
+        CURL=(curl -fsSm 30 -D /dev/stderr --max-redirs 8 --retry-delay 9 --retry 3 --retry-connrefused)
+        CAMO=(grep -o '<img[^>]\+src="https://camo.githubusercontent.com/[^>]*data-canonical-src="'"$BADGEURL"'"[^>]\+>')
+        LINKS=(sed -rn 's/^.*\ssrc="([^"<>]+)".*$/\1/p')
+        echo
         echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]]"
         [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]] || exit 0
+        echo
         data='{"label":"${{ inputs.badge-label }}","color":"${{ inputs.badge-color }}","value":"${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"}'
-        curl -H "Content-Type: application/json" -d "$data" '${{ inputs.badge-service }}/${{ inputs.badge-name }}/${{ inputs.badge-secret }}'
-        echo "Badge URL: ${{ inputs.badge-service }}/${{ inputs.badge-name }}"
+        "${CURL[@]}" -H "Content-Type: application/json" -d "$data" "${BADGEURL}/${{ inputs.badge-secret }}"
+        echo "Badge URL: ${BADGEURL}"
+        [[ '${{ inputs.badge-purge-with }}' == '' ]] && exit 0
+        echo
+        echo 'Purging Camo caches based on ${{ inputs.badge-purge-with }} links'
+        echo
+        "${CURL[@]}" "$CAMO_CHECK_URL" | "${CAMO[@]}" | "${LINKS[@]}" | sort -u > camo.purge.uri
+        echo
+        echo "Purging cache for $(wc -l < camo.purge.uri) Camo entries"
+        echo
+        xargs -ra camo.purge.uri "${CURL[@]}" -X PURGE

--- a/action.yml
+++ b/action.yml
@@ -22,24 +22,26 @@ inputs:
     description: "Code coverage badge color"
     required: true
     default: "99CC09"
+  badge-service:
+    description: "Badge service base URL"
+    required: true
+    default: "https://mineunit-badges.000webhostapp.com/${{ github.repository }}"
+  production-branch:
+    description: "Production branch is what is used for badge generation"
+    required: true
+    default: master
   mineunit-version:
     description: "Mineunit version"
     required: false
 
 outputs:
   # Generated or supplied badge properties
-  badge-name:
-    description: "Code coverage badge name waiting for issues/#1"
-    value: ${{ steps.badge-wrapper-actions-issue-1.outputs.badge-name }}
-  badge-label:
-    description: "Code coverage badge label waiting for issues/#1"
-    value: ${{ steps.badge-wrapper-actions-issue-1.outputs.badge-label }}
+  badge-url:
+    description: "Code coverage badge URL"
+    value: "${{ inputs.badge-service }}/${{ inputs.badge-name }}"
   badge-status:
-    description: "Code coverage badge status waiting for issues/#1"
+    description: "Code coverage badge status"
     value: "${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"
-  badge-color:
-    description: "Code coverage badge color waiting for issues/#1"
-    value: ${{ steps.badge-wrapper-actions-issue-1.outputs.badge-color }}
 
   # Mineunit test framework output
   mineunit-stdout:
@@ -122,10 +124,12 @@ runs:
         echo "::set-output name=total::$(tail -n 2 luacov.report.out | grep ^Total | grep -o '[0-9.]\+%$')"
         awk -v p=0 '/^----/{p++;next}p==2{exit}p' luacov.report.out | sort -hrk4 > luacov.report.sum
         echo "::set-output name=files::$(grep -cv '\s0\.00%' luacov.report.sum)/$(wc -l<luacov.report.sum)"
-    - id: badge-wrapper-actions-issue-1
-      name: Input wrapper while waiting for actions in actions feature
+    - name: generate badge
       shell: bash
       run: |
-        echo "::set-output name=badge-name::${{ inputs.badge-name }}"
-        echo "::set-output name=badge-label::${{ inputs.badge-label }}"
-        echo "::set-output name=badge-color::${{ inputs.badge-color }}"
+        echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ production-branch }}' ]]"
+        [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ production-branch }}' ]] || exit 0
+        echo "Check passed, generating badge"
+        data='{"label":"${{ inputs.badge-label }}","color":"${{ inputs.badge-color }}","value":"${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"}'
+        curl -v -H "Content-Type: application/json" -d "$data" '${{ inputs.badge-service }}/${{ inputs.badge-name }}'
+        echo "Badge URL: ${{ inputs.badge-service }}/${{ inputs.badge-name }}"

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: "Badge service base URL"
     required: true
     default: "https://mineunit-badges.000webhostapp.com/${{ github.repository }}"
+  badge-secret:
+    description: "Badge service API key"
+    required: true
   production-branch:
     description: "Production branch is what is used for badge generation"
     required: true
@@ -129,7 +132,6 @@ runs:
       run: |
         echo "only-if: [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]]"
         [[ '${{ github.event_name }}' == 'push' && '${{ github.ref }}' == 'refs/heads/${{ inputs.production-branch }}' ]] || exit 0
-        echo "Check passed, generating badge"
         data='{"label":"${{ inputs.badge-label }}","color":"${{ inputs.badge-color }}","value":"${{ steps.mineunit-coverage.outputs.total }} in ${{ steps.mineunit-coverage.outputs.files }} files"}'
-        curl -v -H "Content-Type: application/json" -d "$data" '${{ inputs.badge-service }}/${{ inputs.badge-name }}'
+        curl -H "Content-Type: application/json" -d "$data" '${{ inputs.badge-service }}/${{ inputs.badge-name }}/${{ inputs.badge-secret }}'
         echo "Badge URL: ${{ inputs.badge-service }}/${{ inputs.badge-name }}"


### PR DESCRIPTION
Use https://mineunit-badges.000webhostapp.com/

This is currently experimental feature and assumes that everyone plays nice.
Badge service currently runs on some random free hosting service, currently 000webhost.
While service requires GitHub account it does not implement any security for badges, this will be added if it seems to be usable.