### PR TITLE
Upgrade outputs, use rockspec for mineunit deps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,15 +81,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: busted install
+    - name: install mineunit
       shell: bash
       run: |
         sudo apt-get install -y luarocks > /dev/null
-        luarocks install --local busted > /dev/null
-        luarocks install --local cluacov > /dev/null
-    - name: mineunit install
-      shell: bash
-      run: |
         luarocks install --server=https://luarocks.org/dev  --local mineunit ${{ inputs.mineunit-version }}
     - id: mineunit-tests
       name: mineunit runner
@@ -103,10 +98,10 @@ runs:
         exec 3>&-
         grep_eronly=(grep '0 successes / 0 failures / [1-9] error.\? / 0 pending')
         grep_nospec=(grep 'No test files found')
-        ("${grep_eronly[@]}"<<<"$OUT" && "${grep_nospec[@]}"<<<"$OUT")&>/dev/null && echo "::set-output name=spec-missing::true"
+        ("${grep_eronly[@]}"<<<"$OUT" && "${grep_nospec[@]}"<<<"$OUT")&>/dev/null && echo "spec-missing=true" >> $GITHUB_OUTPUT
         OUT="$(sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g'<<<"$OUT")"
         OUT="${OUT//'%'/'%25'}";OUT="${OUT//$'\n'/'%0A'}"
-        echo "::set-output name=stdout::${OUT//$'\r'/'%0D'}"
+        echo "stdout=${OUT//$'\r'/'%0D'}" >> $GITHUB_OUTPUT
         exit $ERR
     - id: mineunit-report
       name: mineunit coverage report
@@ -116,19 +111,19 @@ runs:
         $HOME/.luarocks/bin/mineunit -r
         OUT="$(awk -v p=0 '/^----/{p++;next}p==2{exit}p' luacov.report.out | sort -hrk4)"
         OUT="${OUT//'%'/'%25'}";OUT="${OUT//$'\n'/'%0A'}"
-        echo "::set-output name=report::${OUT//$'\r'/'%0D'}"
+        echo "report=${OUT//$'\r'/'%0D'}" >> $GITHUB_OUTPUT
     - id: mineunit-coverage
       name: collect coverage data
       working-directory: "${{ inputs.working-directory }}"
       shell: bash
       run: |
-        echo "::set-output name=total::$(tail -n 2 luacov.report.out | grep ^Total | grep -o '[0-9.]\+%$')"
+        echo "total=$(tail -n 2 luacov.report.out | grep ^Total | grep -o '[0-9.]\+%$')" >> $GITHUB_OUTPUT
         awk -v p=0 '/^----/{p++;next}p==2{exit}p' luacov.report.out | sort -hrk4 > luacov.report.sum
-        echo "::set-output name=files::$(grep -cv '\s0\.00%' luacov.report.sum)/$(wc -l<luacov.report.sum)"
+        echo "files=$(grep -cv '\s0\.00%' luacov.report.sum)/$(wc -l<luacov.report.sum)" >> $GITHUB_OUTPUT
     - id: badge-wrapper-actions-issue-1
       name: Input wrapper while waiting for actions in actions feature
       shell: bash
       run: |
-        echo "::set-output name=badge-name::${{ inputs.badge-name }}"
-        echo "::set-output name=badge-label::${{ inputs.badge-label }}"
-        echo "::set-output name=badge-color::${{ inputs.badge-color }}"
+        echo "badge-name=${{ inputs.badge-name }}" >> $GITHUB_OUTPUT
+        echo "badge-label=${{ inputs.badge-label }}" >> $GITHUB_OUTPUT
+        echo "badge-color=${{ inputs.badge-color }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Let Luarocks handle dependencies through rockspec instead of manually installing Mineunit dependencies.**
* Fixes #9

**Upgrades to new GitHub workflow output format, next month old format wont work anymore.**
* closes #10