### PR TITLE
Select Lua version

### DIFF
--- a/Dockerfile.lua51
+++ b/Dockerfile.lua51
@@ -1,4 +1,4 @@
-FROM mineunit/mineunit:latest
+FROM mineunit/mineunit:lua51
 
 USER root
 ENV USER=root

--- a/Dockerfile.luajit
+++ b/Dockerfile.luajit
@@ -1,0 +1,11 @@
+FROM mineunit/mineunit:luajit
+
+USER root
+ENV USER=root
+
+RUN apk add --no-cache bash
+
+COPY scripts /scripts
+RUN chmod -R +x /scripts
+
+ENTRYPOINT ["/scripts/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -75,4 +75,4 @@ outputs:
 
 runs:
   using: docker
-  image: Dockerfile.${{ inputs.lua-version }}
+  image: Dockerfile.${{ github.event.inputs.lua-version }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
   lua-version:
     description: "Lua version: lua51 or luajit"
-    required: false
+    required: true
     default: "lua51"
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
   mineunit-version:
     description: "Mineunit version"
     required: false
+  lua-version:
+    description: "Lua version: lua51 or luajit"
+    required: false
+    default: "lua51"
 
 outputs:
   # Generated or supplied badge properties
@@ -71,4 +75,4 @@ outputs:
 
 runs:
   using: docker
-  image: Dockerfile
+  image: Dockerfile.${{ inputs.lua-version }}


### PR DESCRIPTION
## Background

Most of previous release versions of Mineunit were shipped with Lua 5.1.

With latest 0.10 tried with LuaJIT again which at first seemed to work just fine.
However, turns out it doesn't.

## Issues

While testing performace impact of new features I got around 30-40% test set failures with [beerchat tests](https://github.com/mt-mods/beerchat/tree/master/spec).

Interesting thing was that it seemed like if some stuff was executed in separate threads and resulted in race conditions, most of time just randomizing order of output like chat messages sent during tests. I suspected this might be some mistake with async stuff but there should not really be any async stuff there.
Seems this never happens with previous Lua 5.1 version and also not with 0.10 after switching implementation from LuaJIT to Lua 5.1.

Additionally it seems for some reason LuaCov is reporting way lower coverage for [technic tests](https://github.com/mt-mods/technic/tree/master/technic/spec). For this have to investigate further to see if something in Mineunit actually gets disabled or is altered in such way that could affect execution of actual program or if it is LuaJIT / LuaCCov issue (possibly because of aggressive LuaJIT optimizations affecting debugger).

Weird LuaJIT behavior needs more investigation and preferably.

## "solution"

Allow selecting Lua implementation with `lua-version` switch. It accepts either `luajit` or `lua51`.
Default is `lua51` for now.

## Configuration examples

Example configuration to explicitly select LuaJIT:
```yaml
name: mineunit
on: [push, pull_request]
jobs:
  mineunit:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v4
    - id: mineunit
      uses: mt-mods/mineunit-actions@master
      with:
        lua-version: luajit
```

Example configuration to explicitly select Lua 5.1:
```yaml
name: mineunit
on: [push, pull_request]
jobs:
  mineunit:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v4
    - id: mineunit
      uses: mt-mods/mineunit-actions@master
      with:
        lua-version: lua51
```

Example configuration to use default Lua implementation (follow default setting of mt-mods/mineunit-actions):
```yaml
name: mineunit
on: [push, pull_request]
jobs:
  mineunit:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v4
    - id: mineunit
      uses: mt-mods/mineunit-actions@master
```